### PR TITLE
Fixing an important issue

### DIFF
--- a/account.inc
+++ b/account.inc
@@ -68,6 +68,7 @@ hook OnGameModeInit()
 
 hook OnGameModeExit()
 {
+    OnPlayerDisconnect(playerid, 1);
     if(IsValidDB(gDBHandle)) {
         db_close(gDBHandle);
     }


### PR DESCRIPTION
Without calling OnPlayerDisconnect when gamemode exits, the data won't be saved. For example if server crashes for any reason, player's data won't be updated, so we need to call OnPlayerDisconnect manually.